### PR TITLE
sdl-test-ui: add 'f' key to save current preset to favorites.txt

### DIFF
--- a/src/sdl-test-ui/pmSDL.cpp
+++ b/src/sdl-test-ui/pmSDL.cpp
@@ -30,6 +30,7 @@
 
 #include "pmSDL.hpp"
 
+#include <fstream>
 #include <vector>
 
 namespace {
@@ -242,6 +243,7 @@ void projectMSDL::keyHandler(SDL_Event* sdl_evt)
                 this->stretch = false; // if we are toggling fullscreen, ensure we disable monitor stretching.
                 return;                // handled
             }
+            addCurrentPresetToFavorites();
             break;
 
         case SDLK_r:
@@ -476,6 +478,37 @@ std::string projectMSDL::getActivePresetName()
         return presetNameString;
     }
     return {};
+}
+
+void projectMSDL::addCurrentPresetToFavorites()
+{
+    const std::string preset = getActivePresetName();
+    if (preset.empty())
+    {
+        return;
+    }
+
+    const char* path = "favorites.txt";
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line))
+    {
+        if (line == preset)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Already in favorites: %s\n", preset.c_str());
+            return;
+        }
+    }
+    in.close();
+
+    std::ofstream out(path, std::ios::app);
+    if (!out)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to open %s for append\n", path);
+        return;
+    }
+    out << preset << '\n';
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Added to favorites: %s\n", preset.c_str());
 }
 
 void projectMSDL::presetSwitchedEvent(bool isHardCut, unsigned int index, void* context)

--- a/src/sdl-test-ui/pmSDL.hpp
+++ b/src/sdl-test-ui/pmSDL.hpp
@@ -129,6 +129,7 @@ public:
     void pollEvent();
     bool keymod = false;
     std::string getActivePresetName();
+    void addCurrentPresetToFavorites();
     void addFakePCM();
     projectm_handle projectM();
     void setFps(size_t fps);


### PR DESCRIPTION
Press f (no modifier) to append the active preset's path to favorites.txt in the working directory, de-duplicating entries that are already present. Cmd/Ctrl-f remains fullscreen toggle. The resulting list can be replayed via PROJECTM_PRESET_LIST=favorites.txt.